### PR TITLE
Fix: BlockingError

### DIFF
--- a/swampyer/__init__.py
+++ b/swampyer/__init__.py
@@ -569,6 +569,8 @@ class WAMPClient(threading.Thread):
 
                 # Okay, we think we're okay so let's try and read some data
                 data = self.ws.recv()
+            except BlockingIOError:
+                continue
             except websocket.WebSocketTimeoutException:
                 continue
             except websocket.WebSocketConnectionClosedException as ex:


### PR DESCRIPTION
* The BlockingError would occasionally would pop up on the ssl.recv and cause the entire read thread to die. Change the code to ignore and try again.