### PR TITLE
Auto-reconnect improvements

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -51,3 +51,8 @@
 
 1.23 - Tue Sep 25 11:41:36 PDT 2018
 * New version of websocket-client was causing hangs on certain servers when connecting to wss
+
+1.24 - Tue Sep 25 15:05:00 PDT 2018
+* Log a debug message on failed connection attempts with auto_reconnect
+* Store retry seconds in auto_reconnect with default of 1 (Setting True results in default)
+

--- a/examples/01-hello.py
+++ b/examples/01-hello.py
@@ -16,9 +16,10 @@ logging.basicConfig(stream=sys.stdout, level=1)
 
 try:
     client = swampyer.WAMPClient(
-                    url="ws://localhost:8282/ws"
+                    url="ws://localhost:8282/ws",
                     #url="wss://demo.crossbar.io/ws",
                     #realm="crossbardemo",
+                    #auto_reconnect=3
                 ).start()
     print(client)
 except swampyer.SwampyException as ex:

--- a/swampyer/__init__.py
+++ b/swampyer/__init__.py
@@ -117,7 +117,7 @@ class WAMPClient(threading.Thread):
                 authmethods=None,
                 authid=None,
                 timeout=10,
-                auto_reconnect=True,
+                auto_reconnect=1,
                 sslopt=None,
                 sockopt=None,
                 ):
@@ -127,6 +127,8 @@ class WAMPClient(threading.Thread):
         super(WAMPClient,self).__init__()
         self.daemon = True
         self._request_loop_notify_restart = threading.Condition()
+        if auto_reconnect == True:
+            auto_reconnect = 1
         self.configure(
             url = url,
             uri_base = uri_base,
@@ -198,8 +200,14 @@ class WAMPClient(threading.Thread):
                 self.handle_connect()
             except Exception as ex:
                 if self.auto_reconnect:
-                    # FIXME: how long to wait?
-                    time.sleep(1)
+                    logger.debug(
+                        "Error connecting to {url}. Reconnection attempt in {retry} second(s). {err}".format(
+                            url=self.url,
+                            retry=self.auto_reconnect,
+                            err=ex
+                        )
+                    )
+                    time.sleep(self.auto_reconnect)
                     continue
                 else:
                     raise
@@ -694,4 +702,3 @@ class WAMPClientTicket(WAMPClient):
             signature = self.password,
             extra = {}
         ))
-


### PR DESCRIPTION
* Log debug message on failed connection attempts before retry
* Store retry time in seconds in auto_reconnect argument with
  default of 1. (Setting True results in default)