### PR TITLE
Loop timeout

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -78,3 +78,10 @@
 * Change UNSUBSCRIBED message argument name to request_id
 * Return None for unacknowledged publish
 
+1.20190717 - Wed 17 Jul 2019 12:00:00 PDT
+* Implement unsubscribe method to unsubscribe subscription
+
+1.20190724 - Wed 24 Jul 2019 15:02:25 PDT
+* Expose new kwarg loop_timeout to set ws socket timeout as well as main loop timeout values 
+* Stop using create_connection convenience function of websocket_client
+

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@
 from setuptools import setup, find_packages
 
 setup(name='swampyer',
-      version='1.20190717',
+      version='1.20190724',
       description='Simple WAMP library with minimal external dependencies',
       url = 'https://github.com/zabertech/python-swampyer',
-      download_url = 'https://github.com/zabertech/python-swampyer/archive/1.20190716.tar.gz',
+      download_url = 'https://github.com/zabertech/python-swampyer/archive/1.20190724.tar.gz',
       author='Aki Mimoto',
       author_email='aki+swampyer@zaber.com',
       license='MIT',


### PR DESCRIPTION
* Expose new kwarg `loop_timeout` to set ws socket timeout as well as main loop timeout values
* Stop using create_connection convenience function of websocket_client