### PR TITLE
Concurrency events bugfixes

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -112,4 +112,5 @@
 * Refactor to allow subclassing and customizing how invocation/subscription event queues are managed
 * Add some very basic stats to client (messages, invocations, calls, etc). `client.stats()` will return a small dict
 
-
+2.20201020 - Tue Oct 20 10:16:16 PDT 2020
+* Queue events without runners should be handled a bit more gracefully

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@
 from setuptools import setup, find_packages
 
 setup(name='swampyer',
-      version='2.20201014',
+      version='2.20201020',
       description='Simple WAMP library with minimal external dependencies',
       url = 'https://github.com/zabertech/python-swampyer',
-      download_url = 'https://github.com/zabertech/python-swampyer/archive/1.20201014.tar.gz',
+      download_url = 'https://github.com/zabertech/python-swampyer/archive/2.20201020.tar.gz',
       author='Aki Mimoto',
       author_email='aki+swampyer@zaber.com',
       license='MIT',

--- a/swampyer/queues.py
+++ b/swampyer/queues.py
@@ -81,8 +81,16 @@ class ConcurrencyEvent(object):
         self.runner = runner
         self.id = runner and runner.concurrency_id
 
+    def handle_error(self, ex):
+        """ handle_error is only relevant if there's a runner associated
+        """
+        if self.runner:
+            self.runner.handle_error(ex)
+
     def __getattr__(self, k):
-        return getattr(self.runner,k)
+        if self.runner:
+            return getattr(self.runner,k)
+        raise AttributeError('ConcurrencyEvent has no runner so no attribute {k}'.format(k))
 
     __getitem__ = __getattr__
 


### PR DESCRIPTION
Fix handling of when Event.runner is None for events related to rescanning the wait queues.