### PR TITLE
Handle Windows Socket error 10054

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -114,3 +114,6 @@
 
 2.20201020 - Tue Oct 20 10:16:16 PDT 2020
 * Queue events without runners should be handled a bit more gracefully
+
+2.20201210 - Thu Dec 10 08:00:46 UTC 2020
+* Fix regression: Handle Windows Socket error 10054

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='swampyer',
-      version='2.20201020',
+      version='2.20201210',
       description='Simple WAMP library with minimal external dependencies',
       url = 'https://github.com/zabertech/python-swampyer',
       download_url = 'https://github.com/zabertech/python-swampyer/archive/2.20201020.tar.gz',

--- a/swampyer/transport.py
+++ b/swampyer/transport.py
@@ -154,7 +154,7 @@ class WebsocketTransport(Transport):
         """ Returns the next  buffer element
         """
         try:
-            opcode, data = self.socket.recv_data(control_frame=True)
+            opcode, data = self.recv_data(control_frame=True)
 
             if opcode == websocket.ABNF.OPCODE_TEXT:
                 # Try to decode the data as a utf-8 string. Replace any inconvertible characters
@@ -189,7 +189,6 @@ class WebsocketTransport(Transport):
             raise
         except ExWAMPConnectionError:
             raise
-
 
 class RawsocketTransport(Transport):
     """

--- a/swampyer/transport.py
+++ b/swampyer/transport.py
@@ -181,8 +181,14 @@ class WebsocketTransport(Transport):
             return
         except websocket.WebSocketConnectionClosedException as ex:
             raise ExWAMPConnectionError(ex)
-        except (ExWAMPConnectionError, socket.error) as ex:
-            raise 
+        except OSError as ex:
+            # Intended to catch Windows Socket error WSAECONNRESET (10054) which is otherwise unhandled.
+            # https://docs.microsoft.com/en-ca/windows/win32/winsock/windows-sockets-error-codes-2
+            if ex.errno == 10054:
+                raise ExWAMPConnectionError(ex)
+            raise
+        except ExWAMPConnectionError:
+            raise
 
 
 class RawsocketTransport(Transport):

--- a/tests/test_09_windows_socket_error_10054.py
+++ b/tests/test_09_windows_socket_error_10054.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+
+from common import *
+import logging
+import sys
+import time
+
+import swampyer
+
+
+logging.basicConfig(stream=sys.stdout, level=30)
+# We want to see the protocol information
+# being exchanged
+#logging.basicConfig(stream=sys.stdout, level=1)
+
+# If a windows socket error 10054 WSAECONNRESET is caught, raise
+# ExWAMPConnectionError and treat it like any other disconnection
+# If we don't, this creates a nasty spin lock condition
+
+import swampyer.transport
+import swampyer.exceptions
+
+RECV_DATA_ITERATIONS = 0
+
+@swampyer.transport.register_transport('myws')
+class WebsocketTransport(swampyer.WebsocketTransport):
+    throw_errors = False
+
+    def __init__(self, url, **options):
+        # Remove the 'my' portion of myws
+        url =  url[2:]
+        super(WebsocketTransport, self).__init__(url,**options)
+
+    def recv_data(self, control_frame=True):
+        global RECV_DATA_ITERATIONS
+        if self.throw_errors:
+            RECV_DATA_ITERATIONS += 1
+            raise OSError(10054,"Fake OSEerror")
+        return super(WebsocketTransport,self).recv_data(control_frame)
+
+    def next(self):
+        global RECV_DATA_ITERATIONS
+        if RECV_DATA_ITERATIONS > 100:
+            raise swampyer.exceptions.ExWAMPConnectionError("Too many iterations")
+        return super(WebsocketTransport,self).next()
+
+
+def hello(event,data):
+    return data
+
+def test_exception():
+    client = connect_service(url='myws://localhost:18080/ws')
+
+    # Check if we can register
+    reg_result = client.register('com.izaber.wamp.hello', hello, details={"force_reregister": True})
+    assert swampyer.WAMP_REGISTERED == reg_result
+    assert reg_result == swampyer.WAMP_REGISTERED
+
+    client.transport.throw_errors = True
+
+    try:
+        client.register('com.izaber.wamp.hello', hello, details={"force_reregister": True}) 
+    except Exception as ex:
+        pass
+
+    # So when we try and read from the socket, if the bug is in effect, the
+    # os will generate the 10054 error. That creates an incredibly fast churn
+    # loop when what we actually want is to have the system just bail out on the
+    # first pass.
+    assert client.transport == None
+    assert RECV_DATA_ITERATIONS == 1
+
+    # Then shutdown
+    print("SHUTTING DOWN!1")
+    client.shutdown()
+
+    
+if __name__ == '__main__':
+    test_exception()
+


### PR DESCRIPTION
If a windows socket error 10054 WSAECONNRESET is caught, raise
ExWAMPConnectionError and treat it like any other disconnection.