### PR TITLE
Fix agent handling

### DIFF
--- a/VERSIONS.txt
+++ b/VERSIONS.txt
@@ -143,3 +143,8 @@
 3.0.20220626 - Sun Jun 26 11:57:38 PDT 2022
 * Fix RawSocket connections when recv returns fewer bytes than wanted
 * Add SSL RawSocket support
+
+3.0.20220909 - Fri Sep  9 12:04:34 PDT 2022
+* Ensure agent string doesn't get forced to `swampyer-1.0`
+* Now can supply an `agent` argument to `WAMPClient` that can be a simple string but also:
+    agent="myapp-1.2-{platform}" (which will send the platform info)

--- a/swampyer/transport.py
+++ b/swampyer/transport.py
@@ -76,6 +76,7 @@ class WebsocketTransport(Transport):
     subprotocols = None
     fire_cont_frame = False
     skip_utf8_validation = False
+    user_agent = None
 
     def init(self, **options):
 
@@ -104,6 +105,10 @@ class WebsocketTransport(Transport):
         self.fire_cont_frame = options.get('fire_cont_frame',False)
         self.skip_utf8_validation = options.get('skip_utf8_validation',False)
 
+        self.agent = options.get('agent')
+        self.user_agent = options.get('user_agent')
+
+
     def connect(self, **options):
         # Handle the weird issue in websocket that the origin
         # port will be always http://host:port even though connection is
@@ -113,6 +118,12 @@ class WebsocketTransport(Transport):
 
         options.setdefault('sslopt',self.sslopt)
         options.setdefault('subprotocols',self.subprotocols)
+
+        # Include some information on where we're coming from such as OS
+        # and library type if we have access to it
+        header = options.setdefault('header', {})
+        if self.user_agent and isinstance(header, dict):
+            header.setdefault('user-agent', self.user_agent)
 
         self.socket = websocket.WebSocket(
                             fire_cont_frame=options.pop(

--- a/swampyer/transport.py
+++ b/swampyer/transport.py
@@ -9,6 +9,8 @@ import struct
 import socket
 import websocket
 import traceback
+import platform
+from importlib.metadata import version
 
 from .common import *
 from .messages import *
@@ -106,8 +108,14 @@ class WebsocketTransport(Transport):
         self.skip_utf8_validation = options.get('skip_utf8_validation',False)
 
         self.agent = options.get('agent')
-        self.user_agent = options.get('user_agent')
+        user_agent = options.get('user_agent')
+        if user_agent is None:
+            user_agent = "Python Swampyer v{swampyer_version} / {platform}"
 
+        self.user_agent = user_agent.format(
+                             platform = platform.platform(),
+                             swampyer_version = version('swampyer'),
+                        )
 
     def connect(self, **options):
         # Handle the weird issue in websocket that the origin
@@ -119,8 +127,7 @@ class WebsocketTransport(Transport):
         options.setdefault('sslopt',self.sslopt)
         options.setdefault('subprotocols',self.subprotocols)
 
-        # Include some information on where we're coming from such as OS
-        # and library type if we have access to it
+        # Allows us to set the user agent if avaialble
         header = options.setdefault('header', {})
         if self.user_agent and isinstance(header, dict):
             header.setdefault('user-agent', self.user_agent)


### PR DESCRIPTION
* Ensure agent string doesn't get forced to `swampyer-1.0`
* Now can supply an `agent` argument to `WAMPClient` that can be a simple string but also:
    agent="myapp-1.2-{platform}" (which will send the platform info)