### PR TITLE
Allow the transport of datetime and date objects over WAMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,21 @@ poetry install
 Execute by running
 
 ```bash
+./run.sh login
+poetry shell
 nox
+```
+
+Execute a specific nox environment:
+
+```bash
+nox -e <env_name>
+```
+
+Note: a list of available environments can be found with:
+
+```bash
+nox --list-sessions
 ```
 
 ### Packaging

--- a/swampyer/serializers.py
+++ b/swampyer/serializers.py
@@ -10,6 +10,8 @@ import socket
 import websocket
 import traceback
 
+from datetime import date, datetime
+
 from .common import *
 from .utils import logger
 from .exceptions import *
@@ -50,6 +52,8 @@ class JSONSerializer(Serializer):
                     return float(obj)
                 elif isinstance(obj, memoryview):
                     return self.default(bytes(obj))
+                elif isinstance(obj, (datetime, date)):
+                    return obj.isoformat()
                 elif isinstance(obj, bytes):
                     try:
                         return obj.decode()

--- a/tests/test_06_protocols.py
+++ b/tests/test_06_protocols.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from datetime import datetime
 
 from lib import *
 
@@ -31,6 +32,21 @@ def test_connection():
     except UnicodeDecodeError as ex:
         print(f"JSON does not like non-utf8 strings {ex}")
         pass
+    except Exception as ex:
+        raise
+
+    # Send a datetime object, ensure it falls back to
+    # isoformat().
+    obj = datetime.now()
+    try:
+        client_json.publish(
+            'com.izaber.wamp.pub.hello',
+            options={
+            'acknowledge': True,
+            'exclude_me': False,
+            },
+        args=[obj]
+        )
     except Exception as ex:
         raise
 


### PR DESCRIPTION
Currently, `datetime` and `date` objects are not natively JSON serializable and thus are not transportable over WAMP. By overwriting the default() method of `json.JSONEncoder` we can specify the encoding behavior of `datetime` and `date` objects. Using `isoformat()`, we can thus standardize the behavior of dates sent over WAMP which allows us to do cool things such as automatically parsing dates into datetime objects using `fromisoformat()`.